### PR TITLE
Amend non-invertible function definition

### DIFF
--- a/groups.rst
+++ b/groups.rst
@@ -315,8 +315,8 @@ Surjectivity
 
 Another problem that we saw with :math:`f_A` is that we can't invert a function
 if there is some element in the codomain which isn't 'hit' by the function.
-That is, if there's no element :math:`y` in the codomain such that :math:`f(x)
-= y` for some :math:`x` in the domain, we can't invert it, because we don't
+That is, if there's some element :math:`y` in the codomain such that for no
+:math:`x` in the domain :math:`f(x) = y`, we can't invert it, because we don't
 have anything to send :math:`y` to. The function :math:`f : \mathbb{R}
 \rightarrow \mathbb{R}` defined by :math:`f(x) = x^2` also suffers from this
 problem: there's no real number :math:`x` such that :math:`x^2 = -1`, for


### PR DESCRIPTION
The original statement implies, but is not equivalent to, non-surjectivity.
Also, it could be confusing to non-experts as the opening of the sentence sounds like a contradiction of the previous statement (though it is not).